### PR TITLE
Update URLs to honk.wntr.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Winterbloom Big Honking Button
 
-Winterbloom Big Honking Button is an open-source Eurorack module. You can find out more at https://wntr.dev/honk.
+Winterbloom Big Honking Button is an open-source Eurorack module. You can find out more at https://honk.wntr.dev/.
 
 ## License and contributing
 

--- a/firmware/README.HTM
+++ b/firmware/README.HTM
@@ -2,7 +2,7 @@
 <html>
 <body>
 <script>
-location.replace("https://wntr.dev/honk");
+location.replace("https://honk.wntr.dev/");
 </script>
 </body>
 </html>


### PR DESCRIPTION
It seems that https://wntr.dev/honk no longer resolves, so I've updated the references to https://honk.wntr.dev/.

Note: I did *not* update the kicad board text, as I'm not sure what the versioning policy is there.